### PR TITLE
Update import path

### DIFF
--- a/.github/scripts/get-changelog
+++ b/.github/scripts/get-changelog
@@ -27,4 +27,4 @@ fi
 
 >&2 echo "::debug::Merge base ${MERGE_BASE}"
 
-go run github.com/aaronfriel/go-change render --filter-since-commit "${MERGE_BASE}" "${@}"
+go run github.com/pulumi/go-change render --filter-since-commit "${MERGE_BASE}" "${@}"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Update go module dependencies
           pushd ./pkg/test
-          go get -u "github.com/aaronfriel/go-change@v${VERSION}"
+          go get -u "github.com/pulumi/go-change@v${VERSION}"
           go mod tidy
           git add go.mod go.sum
           popd

--- a/changelog/pending/20230811--change-import-path.yaml
+++ b/changelog/pending/20230811--change-import-path.yaml
@@ -1,0 +1,3 @@
+changes:
+- type: chore
+  description: Change import path to github.com/pulumi/go-change.

--- a/cmd/cli_util.go
+++ b/cmd/cli_util.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aaronfriel/go-change/internal/changelog"
 	"github.com/erikgeiser/promptkit/selection"
 	"github.com/erikgeiser/promptkit/textinput"
 	"github.com/muesli/termenv"
+	"github.com/pulumi/go-change/internal/changelog"
 )
 
 func textPrompt(textPrompt string, textPlaceholder string, textValue string) (string, error) {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,9 +21,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/aaronfriel/go-change/internal/changelog"
 	"github.com/goccy/go-yaml"
 	"github.com/gosimple/slug"
+	"github.com/pulumi/go-change/internal/changelog"
 	"github.com/spf13/cobra"
 
 	"github.com/erikgeiser/promptkit/selection"

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aaronfriel/go-change/internal/changelog"
 	"github.com/goccy/go-yaml"
 	"github.com/google/go-github/v47/github"
+	"github.com/pulumi/go-change/internal/changelog"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aaronfriel/go-change
+module github.com/pulumi/go-change
 
 go 1.19
 

--- a/internal/changelog/config.go
+++ b/internal/changelog/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	// Scopes is a map of valid scopes to subscopes
 	Scopes ConfigScopes `yaml:"scopes"`
 
-	// GitHubRepository, e.g.: aaronfriel/go-change
+	// GitHubRepository, e.g.: pulumi/go-change
 	GitHubRepository GitHubRepository `yaml:"github,omitempty"`
 
 	// Template is the template to use for rendering the changelog.

--- a/internal/changelog/config_test.go
+++ b/internal/changelog/config_test.go
@@ -18,7 +18,7 @@ types:
 scopes:
   foo: [bar, baz, thwomp]
   quux: []
-github: aaronfriel/go-change
+github: pulumi/go-change
 `
 	config := MustParseConfig(t, []byte(strings.TrimSpace(testConfigText)))
 	assert.ElementsMatch(t, config.Types.Keys(), []string{"feat", "fix", "chore"})
@@ -42,7 +42,7 @@ scopes:
   - baz
   - thwomp
   quux: []
-github: aaronfriel/go-change
+github: pulumi/go-change
 template:
   template: null
 `)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import cmd "github.com/aaronfriel/go-change/cmd"
+import cmd "github.com/pulumi/go-change/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/test/go.mod
+++ b/pkg/test/go.mod
@@ -1,8 +1,8 @@
-module github.com/aaronfriel/go-change/pkg/test
+module github.com/pulumi/go-change/pkg/test
 
 go 1.19
 
-require github.com/aaronfriel/go-change v0.1.2
+require github.com/pulumi/go-change v0.1.2
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect

--- a/pkg/test/main.go
+++ b/pkg/test/main.go
@@ -1,6 +1,6 @@
 package main
 
-import cmd "github.com/aaronfriel/go-change/cmd"
+import cmd "github.com/pulumi/go-change/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Changes the import path of the repository
to match its new home at github.com/pulumi/go-change.
