### PR TITLE
goreleaser: Use name_template for archive name

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -56,27 +56,30 @@ jobs:
         working-directory: artifacts
         run: sha512sum ./* | tee SHA512SUMS
 
-      - name: Sign checksums
-        working-directory: artifacts
-        shell: bash
-        env:
-          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
-          version: ${{ inputs.version }}
-        run: |
-          set -u
-          echo "$RELEASE_KEY" > release.key
-          set -x
-          for algo in B3 SHA512; do
-            echo | rsign sign \
-              -p "${GITHUB_WORKSPACE}/.github/workflows/release.pub" \
-              -s release.key \
-              -t "${{ inputs.project }} v$version signed with automated key" \
-              -c 'see website for signing information' \
-              -x "${algo}SUMS.auto.minisig" \
-              "${algo}SUMS"
-          done
-          rm release.key
-          cat {B3,SHA512}SUMS.auto.minisig
+      # FIXME: This appears broken.
+      # Ref https://github.com/pulumi/go-change/issues/24
+      #
+      # - name: Sign checksums
+      #   working-directory: artifacts
+      #   shell: bash
+      #   env:
+      #     RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
+      #     version: ${{ inputs.version }}
+      #   run: |
+      #     set -u
+      #     echo "$RELEASE_KEY" > release.key
+      #     set -x
+      #     for algo in B3 SHA512; do
+      #       rsign sign \
+      #         -p "${GITHUB_WORKSPACE}/.github/workflows/release.pub" \
+      #         -s release.key \
+      #         -t "${{ inputs.project }} v$version signed with automated key" \
+      #         -c 'see website for signing information' \
+      #         -x "${algo}SUMS.auto.minisig" \
+      #         "${algo}SUMS"
+      #     done
+      #     rm release.key
+      #     cat {B3,SHA512}SUMS.auto.minisig
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,12 +14,13 @@ builds:
       - amd64
       - arm64
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
archive.replacements has been deprecated
so we should use archive.name_template.

Ref https://goreleaser.com/deprecations/#archivesreplacements
Blocks #22
