### PR TITLE
Use active imperative mood for changelog entries

### DIFF
--- a/changelog/pending/20240301--use-imperative-mood.yaml
+++ b/changelog/pending/20240301--use-imperative-mood.yaml
@@ -1,0 +1,3 @@
+changes:
+- type: feat
+  description: Make the prompt suggest the imperative mood

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -86,7 +86,7 @@ func newCreateCmd() *cobra.Command {
 			// Get desc from argument or prompt:
 			if len(desc) == 0 {
 				for {
-					desc, err = textPrompt("Description of change?", "Fixes bug, adds feature, updates dependencies, etc.", desc)
+					desc, err = textPrompt("Description of change?", "Fix bug, add feature, update dependencies, etc.", desc)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
In pulumi/pulumi we're discussing using the active imperative mood consistently for changelog entries.  However `go-change` currently doesn't use that.  Adjust the prompt to suggest the right mood for changelog entries.  This also matches the style that's usually suggested for git commit messages.